### PR TITLE
Only err for exceptional errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}"
+      "program": "${workspaceFolder}/cmd/secrets"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -30,23 +30,25 @@ from the default environment e.g.,
 package main
 
 import (
-	"errors"
-	"fmt"
-	"os"
+    "errors"
+    "fmt"
+    "os"
 
-	"github.com/heaths/go-dotazure"
+    "github.com/heaths/go-dotazure"
 )
 
 func main() {
-	if err := dotazure.Load(); err != nil && !errors.Is(err, os.ErrNotExist) {
-		panic(err)
-	}
+    if loaded, err := dotazure.Load(); err != nil {
+        panic(err)
+    } else if loaded {
+        fmt.Fprintln(os.Stderr, "loaded environment variables")
+    }
 
-	// Assumes bicep contains e.g.
-	//
-	// output AZURE_KEYVAULT_URL string = kv.properties.vaultUri
-	vaultURL, _ := os.LookupEnv("AZURE_KEYVAULT_URL")
-	fmt.Printf("AZURE_KEYVAULT_URL=%q\n", vaultURL)
+    // Assumes bicep contains e.g.
+    //
+    // output AZURE_KEYVAULT_URL string = kv.properties.vaultUri
+    vaultURL, _ := os.LookupEnv("AZURE_KEYVAULT_URL")
+    fmt.Printf("AZURE_KEYVAULT_URL=%q\n", vaultURL)
 }
 ```
 

--- a/cmd/secrets/main.go
+++ b/cmd/secrets/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -15,8 +14,10 @@ import (
 )
 
 func main() {
-	if err := dotazure.Load(); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if loaded, err := dotazure.Load(); err != nil {
 		panic(err)
+	} else if loaded {
+		fmt.Fprintln(os.Stderr, "loaded environment variables")
 	}
 
 	vaultURL, _ := os.LookupEnv("AZURE_KEYVAULT_URL")


### PR DESCRIPTION
Returns a boolean whether the .env file was found and loaded successfully. Errors are only returned for exceptional circumstances like files that should be directories, vice versa, or corrupt / invalid data files we need to read.
